### PR TITLE
Fixed installation so that all .py files and templates are copied.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+recursive-include debug_toolbar_extras *.py *.html

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name = "django-debug-toolbar-extras",
@@ -8,9 +8,8 @@ setup(
     description = "A collection of add-on panels for Django's debug_toolbar.",
     url = "http://github.com/crass/django-debug-toolbar-extras/",
     license = "BSD",
-    packages = [
-        "debug_toolbar_extras",
-    ],
+    packages = find_packages(),
+    include_package_data = True,
     classifiers = [
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",


### PR DESCRIPTION
Fixes #4 - all .py files and templates are now copied when you install with pip.
